### PR TITLE
Move ddns-start script to repo

### DIFF
--- a/Data/asuswrt-ovh-ddns-start.sh
+++ b/Data/asuswrt-ovh-ddns-start.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+###
+# Based on 
+# https://github.com/RMerl/asuswrt-merlin/wiki/Custom-DDNS#google-domains
+# https://github.com/RMerl/asuswrt-merlin/wiki/Custom-DDNS#bind9-ddns-using-nsupdate
+#
+# Forked from
+# https://gist.github.com/atais/9ea6595072096ab8077f619bd3648da8
+###
+
+set -u
+
+U=user
+P=password
+H=domain
+
+# args: username password hostname ip
+ovh_dns_update() {
+  CMD=$(curl -s -u $1:$2 "https://www.ovh.com/nic/update?system=dyndns&hostname=$3&myip=$4")
+  logger "ovh-ddns-updated: $CMD"
+  case "$CMD" in
+    good*|nochg*) /sbin/ddns_custom_updated 1 ;;
+    *) /sbin/ddns_custom_updated 0 ;;
+  esac
+}
+
+### When double NATed behind ISP's router this line gets IP from outside, otherwise, comment out next line.
+IP=$(wget -O - -q http://myip.dnsomatic.com/)
+# last parameter is IP, use $IP
+ovh_dns_update $U $P $H $IP
+
+exit 0

--- a/Readme.fr.md
+++ b/Readme.fr.md
@@ -110,11 +110,11 @@ A noter qu'il est possible créer une redirection wildcard. Il suffit pour cela 
 >![Redirection Ovh 5](https://i.imgur.com/0II2GZY.png)  
 
 ### 4.2. Côté routeur
-Pour que le routeur puisse mettre à jour l'adresse ip sur laquelle pointe le domaine, il faut utiliser la fonction DDNS du routeur. Par défaut, une série de fournisseurs comme no-ip est proposée, mais pas Ovh. Il faut donc créer un script personnel. Vous avez de la chance, j'en ai testé et adapté [un](https://gist.github.com/pedrom34/0bfdf2bb7f2e17a8859c1fad7204d7bf).  
+Pour que le routeur puisse mettre à jour l'adresse ip sur laquelle pointe le domaine, il faut utiliser la fonction DDNS du routeur. Par défaut, une série de fournisseurs comme no-ip est proposée, mais pas Ovh. Il faut donc créer un script personnel. Vous avez de la chance, j'en ai testé et adapté [un](https://github.com/pedrom34/TutoAsus/raw/master/Data/asuswrt-ovh-ddns-start.sh).  
   
 On se connecte au routeur via le terminal, et :
 ```shell
-wget https://gist.githubusercontent.com/pedrom34/0bfdf2bb7f2e17a8859c1fad7204d7bf/raw/d92e3c5f87afd6b0870db8a8eb0fd597ec904a7c/asuswrt-ovh-ddns.sh -O /jffs/scripts/ddns-start
+wget https://github.com/pedrom34/TutoAsus/raw/master/Data/asuswrt-ovh-ddns-start.sh -O /jffs/scripts/ddns-start
 ``` 
 Puis on édite le script téléchargé.
 ```shell

--- a/Readme.md
+++ b/Readme.md
@@ -111,11 +111,11 @@ It is also possible to create a wildcard redirect. Just delete the existing CNAM
 >![Redirection Ovh 5](https://i.imgur.com/0II2GZY.png)  
 
 ### 4.2. Router side
-In order for the router to update the ip address to which the domain points, you must use the router's DDNS function. By default, a series of suppliers like no-ip is proposed, but not Ovh. So you have to create a personal script. You are lucky, I tested and adapted [one](https://gist.github.com/pedrom34/0bfdf2bb7f2e17a8859c1fad7204d7bf).  
+In order for the router to update the ip address to which the domain points, you must use the router's DDNS function. By default, a series of suppliers like no-ip is proposed, but not Ovh. So you have to create a personal script. You are lucky, I tested and adapted [one](https://github.com/pedrom34/TutoAsus/raw/master/Data/asuswrt-ovh-ddns-start.sh).  
   
 We connect to the router via the terminal, and:
 ```shell
-wget https://gist.githubusercontent.com/pedrom34/0bfdf2bb7f2e17a8859c1fad7204d7bf/raw/d92e3c5f87afd6b0870db8a8eb0fd597ec904a7c/asuswrt-ovh-ddns.sh -O /jffs/scripts/ddns-start
+wget https://github.com/pedrom34/TutoAsus/raw/master/Data/asuswrt-ovh-ddns-start.sh -O /jffs/scripts/ddns-start
 ``` 
 Then we edit the downloaded script.
 ```shell


### PR DESCRIPTION
The ddns-start script is moved from gist to this repo.