### PR TITLE
Don't use JFFS partition for acme.sh scripts!

### DIFF
--- a/Readme.fr.md
+++ b/Readme.fr.md
@@ -371,24 +371,24 @@ Alors, on commence par télécharger Acme.sh
 wget https://github.com/Neilpang/acme.sh/archive/master.zip
 ```
 
-Décompresser l'archive. J'ai choisi de décompresser l'archive dans /jffs. Mais de toutes façons, ce dossier sera supprimé après.
+Décompresser l'archive. J'ai choisi de décompresser l'archive dans /opt (ce qui correspond à la clé usb branchée sur le routeur). Mais de toutes façons, ce dossier sera supprimé après.
 ```shell
-unzip master.zip -d /jffs
+unzip master.zip -d /opt
 ```
 
 On va dans le dossier dézippé :
 ```shell
-cd /jffs/acme.sh-master/
+cd /opt/acme.sh-master/
 ```
 
 On rend le script exécutable
 ```shell
-chmod a+x /jffs/acme.sh-master/*
+chmod a+x /opt/acme.sh-master/*
 ```
 
-Et on installe le script dans /jffs/scripts/acme.sh, l'argument "--home" permet de définir l'emplacement de l'installation ; cet argument devra être utilisé à CHAQUE FOIS. La partition jffs sera conservée lors d'un reboot. Il est donc conseillé d'installer le script dedans.
+Et on installe le script dans /opt/scripts/acme.sh, l'argument "--home" permet de définir l'emplacement de l'installation ; cet argument devra être utilisé à CHAQUE FOIS.  
 ```shell
-./acme.sh --install --home "/jffs/scripts/acme.sh"
+./acme.sh --install --home "/opt/scripts/acme.sh"
 ```
 ### 7.2. Création des clés api de Ovh
 Je configure le script pour qu'il utilise l'api d'Ovh pour créer des champs TXT dans les enregistrements de domaine, justifiant ainsi ma propriété pour Let's Encrypt. 
@@ -396,7 +396,7 @@ Je configure le script pour qu'il utilise l'api d'Ovh pour créer des champs TXT
 On crée les clés sur https://eu.api.ovh.com/createApp/  
 Notez bien les informations affichées, puis, dans le terminal, on se rend le dossier acme.sh
 ```shell
-cd /jffs/scripts/acme.sh
+cd /opt/scripts/acme.sh
 ```
 
 Et on installe les clés d'api Ovh que l'on a eu à l'étape précédente, en tapant dans le terminal (remplacez par vos informations) :
@@ -407,7 +407,7 @@ export OVH_AS="Ovh Application Secret"
   
 Ensuite, on génère le certificat, ici, on voit que je demande un certificat wildcard \*.domain.tld* ainsi que pour la racine du domaine (domain.tld).
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
+./acme.sh --home "/opt/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
 ```
   
 Quoi qu'il en soit, cela va échouer, et renvoyer un message d'erreur comme suivant :
@@ -426,12 +426,12 @@ En effet, il faut se rendre, la première fois uniquement, à l’adresse qu'ind
   
 Ensuite, on recommence, cette fois, ça doit fonctionner :
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
+./acme.sh --home "/opt/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
 ```
   
 On installe le script dans nginx.
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --install-cert -d domain.tld \
+./acme.sh --home "/opt/scripts/acme.sh" --install-cert -d domain.tld \
 --key-file       /opt/etc/nginx/cert.key  \
 --fullchain-file /opt/etc/nginx/cert.crt \
 --reloadcmd     "/opt/etc/init.d/S80nginx reload"
@@ -440,17 +440,17 @@ A noter, que le chemin que j'indique pour la clé et le certificat est celui ind
   
 On ajoute ensuite une ligne au fichier services-start pour le renouvellement automatique des certificats, qui se lancera tous les jours à 2h du matin. Pour cela, il faut faire *vi /jffs/scripts/services-start* et on agjoute cette ligne (pour ça, on tape i, puis Esc et ZZ quand c’est collé) :
 ```shell
-cru a "acme.sh" '0 2 * * * /jffs/scripts/acme.sh/acme.sh --cron --home "/jffs/scripts/acme.sh" > /dev/null'
+cru a "acme.sh" '0 2 * * * /opt/scripts/acme.sh/acme.sh --cron --home "/opt/scripts/acme.sh" > /dev/null'
 ```
   
 On active la mise à jour automatique de acme.sh via la ligne de commande suivante :
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --upgrade --auto-upgrade
+./acme.sh --home "/opt/scripts/acme.sh" --upgrade --auto-upgrade
 ```
 
 On peut supprimer le dossier acme.sh-master présent dans jffs.
 ```shell
-rm -r /jffs/acme.sh-master/
+rm -r /opt/acme.sh-master/
 ```
   
 Et on peut enfin lancer nginx :

--- a/Readme.md
+++ b/Readme.md
@@ -373,24 +373,24 @@ So, we start with downloading the script.
 wget https://github.com/Neilpang/acme.sh/archive/master.zip
 ```
   
-Unzip the archive. I chose to unzip it to /jffs. In any cases, the folder will be deleted afterwards.
+Unzip the archive. I chose to unzip it to /opt, that is the usb device plugged in. In any cases, the folder will be deleted afterwards.
 ```shell
-unzip master.zip -d /jffs
+unzip master.zip -d /opt
 ```
   
 Go to the folder
 ```shell
-cd /jffs/acme.sh-master/
+cd /opt/acme.sh-master/
 ```
   
 Make the script executable.
 ```shell
-chmod a+x /jffs/acme.sh-master/*
+chmod a+x /opt/acme.sh-master/*
 ```
   
-And then install the script to /jffs/scripts/acme.sh, the "--home" argument allows you to define the installation folder; this argument must be used EVERY TIME. The jffs partition will be kept during a reboot. It is therefore recommended to install the script inside.
+And then install the script to /opt/scripts/acme.sh, the "--home" argument allows you to define the installation folder; this argument must be used EVERY TIME. 
 ```shell
-./acme.sh --install --home "/jffs/scripts/acme.sh"
+./acme.sh --install --home "/opt/scripts/acme.sh"
 ```
 ### 7.2. Ovh API keys
 I configure the script to use Ovh API to create TXT fields in domain records, thus justifying my property for Let's Encrypt. 
@@ -398,7 +398,7 @@ I configure the script to use Ovh API to create TXT fields in domain records, th
 The keys are created on https://eu.api.ovh.com/createApp/  
 Make a note of the information displayed, then, in the terminal, go to the acme.sh folder
 ```shell
-cd /jffs/scripts/acme.sh
+cd /opt/scripts/acme.sh
 ```
 
 And install the Ovh API keys that we got in the previous step, by typing in the terminal (replace by your information):
@@ -409,7 +409,7 @@ export OVH_AS="Ovh Application Secret"
   
 Then, generate the certificate. Here, we can see that I request a wildcard certificate \*.domain.tld* as well as for the root domain (domain.tld).
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
+./acme.sh --home "/opt/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
 ```
   
 Anyway, it will fail, and return an error message like this:
@@ -428,12 +428,12 @@ Indeed, you must go, the first time only, to the address indicated in the script
   
 Then do it again, this time it will work:
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
+./acme.sh --home "/opt/scripts/acme.sh" --issue -d *.domain.tld -d domain.tld --dns dns_ovh
 ```
   
 Install the script in nginx.
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --install-cert -d domain.tld \
+./acme.sh --home "/opt/scripts/acme.sh" --install-cert -d domain.tld \
 --key-file       /opt/etc/nginx/cert.key  \
 --fullchain-file /opt/etc/nginx/cert.crt \
 --reloadcmd     "/opt/etc/init.d/S80nginx reload"
@@ -442,17 +442,17 @@ Note that the path I indicate for the key and the certificate is the one indicat
   
 We need to add a line to services-start for the automatic renewal of certificates, which will be launched every day at 2am. To do so, we need to type *vi /jffs/scripts/services-start* and then add this line (again, type i, then Esc and ZZ once you pasted the line):
 ```shell
-cru a "acme.sh" '0 2 * * * /jffs/scripts/acme.sh/acme.sh --cron --home "/jffs/scripts/acme.sh" > /dev/null'
+cru a "acme.sh" '0 2 * * * /opt/scripts/acme.sh/acme.sh --cron --home "/opt/scripts/acme.sh" > /dev/null'
 ```
 
 The automatic update of acme.sh is activated via the following command line:
 ```shell
-./acme.sh --home "/jffs/scripts/acme.sh" --upgrade --auto-upgrade
+./acme.sh --home "/opt/scripts/acme.sh" --upgrade --auto-upgrade
 ```
 
-The acme.sh-master folder in jffs can now be deleted.
+The acme.sh-master folder in opt can now be deleted.
 ```shell
-rm -r /jffs/acme.sh-master/
+rm -r /opt/acme.sh-master/
 ```
   
 And finally you can start nginx:


### PR DESCRIPTION
J'avais l'habitude d'installer les scripts acme.sh dans la partition /jffs. Ce n'est pas vraiment une bonne pratique, car cela pourrait user cette partition mémoire. Si cette partition est endommagée, vous devrez changer votre routeur :disappointed:  Regardez https://github.com/RMerl/asuswrt-merlin.ng/wiki/JFFS pour plus d'informations.

I used to install acme.sh scripts into /jffs partition. That's not really a good practice, since it might wear out this memory partition. If this partition is out, you'll have to change your router :disappointed:  Please see https://github.com/RMerl/asuswrt-merlin.ng/wiki/JFFS for more info.